### PR TITLE
wip: introduce a "build dev" command

### DIFF
--- a/lib/kamal/cli/build.rb
+++ b/lib/kamal/cli/build.rb
@@ -9,6 +9,25 @@ class Kamal::Cli::Build < Kamal::Cli::Base
     pull
   end
 
+  desc "dev", "Build development app image using the local directory as the build context"
+  def dev
+    verify_local_dependencies
+
+    uncommitted_changes = Kamal::Git.uncommitted_changes
+    if uncommitted_changes.present?
+      say "WARNING: building with uncommitted changes:\n #{uncommitted_changes}", :yellow
+    end
+
+    with_env(KAMAL.config.builder.secrets) do
+      run_locally do
+        build_and_load = KAMAL.builder.dev
+        KAMAL.with_verbosity(:debug) do
+          execute(*build_and_load)
+        end
+      end
+    end
+  end
+
   desc "push", "Build and push app image to registry"
   def push
     cli = self

--- a/lib/kamal/commands/builder.rb
+++ b/lib/kamal/commands/builder.rb
@@ -1,7 +1,7 @@
 require "active_support/core_ext/string/filters"
 
 class Kamal::Commands::Builder < Kamal::Commands::Base
-  delegate :create, :remove, :push, :clean, :pull, :info, :inspect_builder, :validate_image, :first_mirror, to: :target
+  delegate :create, :remove, :dev, :push, :clean, :pull, :info, :inspect_builder, :validate_image, :first_mirror, to: :target
   delegate :local?, :remote?, to: "config.builder"
 
   include Clone

--- a/lib/kamal/commands/builder/base.rb
+++ b/lib/kamal/commands/builder/base.rb
@@ -13,6 +13,18 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
     docker :image, :rm, "--force", config.absolute_image
   end
 
+  def dev
+    dev_build_tags = build_tags.each_slice(2).flat_map { |flag, name| [ flag, "#{name}-dev" ] }
+    options = build_options - build_tags + dev_build_tags
+
+    docker :buildx, :build,
+      "--load",
+      *platform_options(arches),
+      *([ "--builder", builder_name ] unless docker_driver?),
+      *options,
+      build_context
+  end
+
   def push
     docker :buildx, :build,
       "--push",


### PR DESCRIPTION
which:

- builds from the local directory, even if there are uncommitted changes
- loads the resulting buildx image into the docker image cache
- tags the images with a `-dev` suffix to differentiate from the pristine images